### PR TITLE
Separate the configuration from the script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ These configs and G-code are made specifically for *PrusaSlicer.* They might wor
 
 Since PrusaSlicer version 2.2, I'm now making releases for these configs with the same version as the PrusaSlicer version they were made for. If for some reason you are using an older version of PrusaSlicer, you should take the .ini file from the release of my configs with the same older version, to avoid backwards compatibility issues.
 
-This repository contains four things:
+This repository contains five things:
 
 1. **ConfigBundles:** the main PrusaSlicer config bundle. This is the bare minimum to get things working, but you should preferably also install the next thing:
 2. **`make_fcp_x3g.pl`:** a post-processing script that can automate the essential GCode-to-X3G conversion for you, as well as work around an annoying bug in PrusaSlicer, and optionally also invoke certain extra post-processing scripts. You can make do without this script, but it can make your workflow a lot easier.
-3. **Optional-postprocessing-scripts:** what the name says. See the README inside that directory for more info.
-4. **GCode:** the same G-code snippets that are already embedded into the config bundles, strictly spoken you can ignore this. It is possible that I will make small updates to these snippets without updating the whole config bundles, because that's kind of a hassle. If you see more recent commits in this **GCode** folder than inside the **ConfigBundles** folder and you want the latest and greatest, [follow the instructions on my site](https://www.dr-lex.be/software/ffcp-slic3r-profiles.html#gcode) to update them.
+3. **`make_fcp_x3g.txt`:** a template for the configuration file needed by the post-processing script. Simplest is to ensure that the filled-in template is in the same directory as where you place the script.
+4. **Optional-postprocessing-scripts:** what the name says. See the README inside that directory for more info.
+5. **GCode:** the same G-code snippets that are already embedded into the config bundles, strictly spoken you can ignore this. It is possible that I will make small updates to these snippets without updating the whole config bundles, because that's kind of a hassle. If you see more recent commits in this **GCode** folder than inside the **ConfigBundles** folder and you want the latest and greatest, [follow the instructions on my site](https://www.dr-lex.be/software/ffcp-slic3r-profiles.html#gcode) to update them.
 
 
 ## A warning in advance
@@ -25,7 +26,7 @@ You should never exceed 240°C for longer than a few minutes if you have not upg
 
 If you have a question, please go through both [the companion webpage](https://www.dr-lex.be/software/ffcp-slic3r-profiles.html) and this README (again). I will most likely not answer any mails that ask something already clearly explained on any of those two pages. If you think parts of this README can be improved, the best thing you can do is provide the improved text, for instance by creating a new GitHub issue or maybe even a pull request, or just by sending the remarks through the contact page of [my website](https://www.dr-lex.be/).
 
-If you are truly stuck and need to contact me, make sure to mention what operating system you are using, and any other possibly relevant information that could help with troubleshooting.
+If you are truly stuck and need to contact me, make sure to mention what operating system you are using, what version of PrusaSlicer, and any other possibly relevant information that could help with troubleshooting.
 
 
 ## Step 1: install the `make_fcp_x3g.pl` script
@@ -39,15 +40,17 @@ Important: if you are going to use the WSL Linux environment in Windows, do not 
 
 As for the post-processing script itself, you need it regardless of whether you use OctoPrint or not. Your options are:
 
-1. **You are running Linux or Mac OS X:** open the `make_fcp_x3g.pl` Perl script in an editor, and modify it according to its instructions until you hit the “`No user serviceable parts`” line. When done, ensure the file is executable (`chmod a+x make_fcp_x3g.pl`) and remember the **full absolute path** to where you placed it. This will be referred to as `PATH` below. A suitable location would be a ‘bin’ folder in your home directory where you might also store other personal executable files. (An easy way to obtain the absolute path in Mac OS and many recent Linux UIs, is to drag the file into a terminal window.)\
+1. **You are running Linux or Mac OS X:** copy both `make_fcp_x3g` files (`.pl` and `.txt`) to the same location of your choice, and open `make_fcp_x3g.txt` in a text editor. Modify it according to its instructions. When done, ensure the `make_fcp_x3g.pl` file is executable (`chmod a+x make_fcp_x3g.pl`) and remember the **full absolute path** to where you placed it. This will be referred to as `PATH` below. A suitable location would be a ‘bin’ folder in your home directory where you might also store other personal executable files. (An easy way to obtain the absolute path in Mac OS and many recent Linux UIs, is to drag the file into a terminal window.)\
    Try running the script with `-c` argument to see whether you configured it correctly. In Linux, you may need to install the `File::Which` Perl module (Debian or Ubuntu package `libfile-which-perl`).\
    You can now move to *step 2.*
-2. **You use a Perl interpreter in Windows:** this is the easiest way to use the script in Windows. I recommend [Strawberry Perl](https://strawberryperl.com/). Copy the script to a location where you have write permissions, and open it in an editor (I recommend [Notepad++](https://notepad-plus-plus.org/)). Modify the script according to its instructions until you hit the “`No user serviceable parts`” line. When done, figure out the full paths to both the Perl executable and the script. To obtain what will be referred to as `PATH` below, put the `perl.exe` path between double quotes, followed by a space, then the script path between double quotes. For instance if you installed Strawberry Perl in its default location, then `PATH` would look like:\
+2. **You use a Perl interpreter in Windows:** this is the easiest way to use the script in Windows. I recommend [Strawberry Perl](https://strawberryperl.com/). Copy both `make_fcp_x3g` files (`.pl` and `.txt`) to the same location where you have write permissions. A subdirectory of your user home folder is a good place (a Windows system directory is not).<br>
+   Open `make_fcp_x3g.txt` in a text editor (I recommend [Notepad++](https://notepad-plus-plus.org/)). Modify it according to its instructions. When done, figure out the full paths to both the Perl executable and the `make_fcp_x3g.pl` script. To obtain what will be referred to as `PATH` below, put the `perl.exe` path between double quotes, followed by a space, then the script path between double quotes. For instance if you installed Strawberry Perl in its default location, then `PATH` would look like:\
    `"C:\Strawberry\perl\bin\perl.exe" "C:\path\to\make_fcp_x3g.pl"`\
    or if you would be using 64-bit Cygwin:\
    `"C:\cygwin64\bin\perl.exe" "C:\path\to\make_fcp_x3g.pl"`\
+   Try running the script in a command shell with `-c` argument to see whether you configured it correctly. Just paste your value of PATH into a cmd shell and append `-c` at the end with a space before it. Fix any problems until it reports “OK.”
    You can now move to *step 2.*
-3. **You are running WSL inside Windows:** this is more complicated but if you already have WSL, then it makes more sense to rely on its Perl interpreter than to install yet another one in Windows. You need the `make_fcp_x3g.pl` script, but also a BAT wrapper script to invoke it from within Windows. Follow the *‘WSL instructions’* subsection below.
+3. **You are running WSL inside Windows:** this is more complicated but if you already have WSL, then it makes more sense to rely on its Perl (and maybe Python) interpreter than to install yet another one in Windows. You need the `make_fcp_x3g.pl` script, but also a BAT wrapper script to invoke it from within Windows. Follow the *‘WSL instructions’* subsection below.
 
 The above list is sorted from most to least recommended when it comes to ease and functionality. This indeed means that if you have the choice between either, then Linux or Mac OS are preferable over Windows when it comes to running PrusaSlicer with these post-processing scripts.
 
@@ -57,9 +60,9 @@ This is only relevant if you want to run the scripts inside WSL. Otherwise, skip
 
 For this to work, inside your WSL environment you must have a command `wslpath` that converts Windows paths to their Linux equivalent. This is automatically the case if you have Windows 10 version 1803 or newer with a standard WSL image. If not, follow the instructions in the file `poor_mans_wslpath.txt`. Your WSL version must also support the `WSLPATH` variable, which should be the case for any recent build.
 
-Open the `make_fcp_x3g.pl` script in a text editor and modify it according to its instructions until you hit the “`No user serviceable parts`” line. Important: each time you need to specify the path to a program or script, specify the *Linux file path* where you placed that program (e.g. gpx) or script inside the WSL Linux environment.
+Copy both `make_fcp_x3g` files (`.pl` and `.txt`) to the same location of your choice *inside the WSL environment.* Open `make_fcp_x3g.txt` in a text editor and modify it according to its instructions. Important: everything will run inside WSL, therefore each time you need to specify the path to a program or script, specify the *Linux file path* where you placed that program (e.g. gpx) or script inside the WSL Linux environment.
 
-When done, save the modified `make_fcp_x3g.pl` inside the Linux filesystem. Ensure both the script and gpx binary (if needed) are executable (`chmod a+x make_fcp_x3g.pl`).
+When done, ensure both the script and gpx binary (if needed) are executable (`chmod a+x make_fcp_x3g.pl`).
 
 You should now run the script with `-c` argument to check whether it works. It is possible you will have to install the `File::Which` Perl module, which can be done in Ubuntu with:
 ```

--- a/make_fcp_x3g.txt
+++ b/make_fcp_x3g.txt
@@ -1,0 +1,156 @@
+### MAKE_FCP_X3G CONFIGURATION FILE ###
+
+# Either put this file in the same location as the make_fcp_x3g.pl script
+#   and ensure it is called "make_fcp_x3g.txt",
+# or pass this file's path to the script with the '-f' parameter.
+# (If you are using a symlink to the .pl script, then the script will use that
+#   symlink's directory for the default config location.)
+#
+# Modify the values below according to your environment and preferences.
+# Lines starting with # are comments and will be ignored.
+# Remove the '#' before a line to enable it, add one to disable it.
+#
+# The format of a valid configuration item is very simple:
+#   ITEM_NAME = a value or an array of values.
+#
+# You can always specify an array, but items marked as [SINGLE] will only
+#   consider the first element if you would pass an array. Items that will
+#   consider multiple elements are marked as [ARRAY].
+# If you need more than a single element in an [ARRAY] value, you must put
+#   EACH element between double quotes. For a [SINGLE] value or an [ARRAY]
+#   with only 1 element, you can omit the quotes. Some examples:
+# EXAMPLE_ARRAY1 = "first element" "second element"
+# EXAMPLE_ARRAY2 = this array has only 1 element because no quotes
+# EXAMPLE_VALUE1 = "you could enclose a SINGLE in quotes"
+# EXAMPLE_VALUE2 = or just omit them
+#
+# Any whitespace around '=', as well as at the end of the line, is ignored.
+# There are no escape characters, everything is literal. This means you cannot
+#   really use a double quote anywhere, except to delineate values. None of
+#   the values should ever need to contain a double quote.
+#
+# Avoid non-ASCII characters. If you cannot avoid them, try saving this file
+#   in the same codepage as your operating system uses for file paths. Often
+#   this will be UTF-8, but it may be different. You're on your own here.
+
+
+### GLOBAL CONFIGURATION ###
+
+# [SINGLE] Set this to 1 to always keep a backup of the unprocessed G-code
+#   file, regardless of -k option (useful for debugging).
+
+KEEP_ORIG = 0
+
+# [SINGLE] Set this to 1 to force debug mode (regardless of -d option).
+#   This is useful to debug problems when invoking make_fcp_x3g.pl from within
+#   PrusaSlicer or other programs, and not all post-processing steps seem to
+#   be working.
+
+DEBUG = 0
+
+# [SINGLE] Optional extra execution path elements.
+#   If you want to augment the very basic execution PATH inside PrusaSlicer's
+#   post-processing environment, you can add extra path components here.
+# In UNIX-like environments: separate components by colons ':'.
+# In Windows cmd.exe: separate components by semicolons ';'.
+# You can simply leave this empty and use full absolute paths everywhere.
+#   The advantage of correctly setting this, is that you can use the plain
+#   names of executables (like perl or python3) instead of their full paths.
+
+#EXTRA_PATH = /usr/local/bin:/usr/local/sbin
+
+
+### OPTIONAL POST-PROCESSING STEPS ###
+
+# Enable what you want or need. Leave the rest commented out.
+#
+# RULES:
+# * Do not use relative paths.
+# * All paths are CASE SENSITIVE regardless of how your OS treats case
+#   sensitivity. "Perl" is not the same as "perl".
+# * No path can contain a double quote, even if your OS allows it.
+# * Do not try to override the -o option in extra post-processing scripts.
+# * The best way to disable something is to put a '#' before it to comment out
+#   its line. An empty value is also OK.
+# * Incorrect paths or non-executable script files will be silently ignored at
+#   runtime. They will only be reported when running the script with the
+#   sanity check (-c) option. Do this after saving this config, to ensure you
+#   did not make any mistakes.
+# HINT:
+# Avoid manually typing paths! Pretty much every OS has a way of directly
+#   obtaining a file's path. For instance in Windows: right-click the file
+#   while holding down shift and use "Copy as path".
+
+# [SINGLE] Path to the gpx binary that converts gcode to printable files.
+#   If the binary can be found in (EXTRA_)PATH, just 'gpx' suffices.
+#   Otherwise, specify the full path (you might be able to obtain it with
+#   `which gpx` in UNIX-like systems, or `where gpx` in Windows).
+# To disable conversion to X3G (and leave it up to e.g. OctoPrint), comment
+#   out the line or set an empty value.
+
+#GPX = /usr/local/bin/gpx
+
+# The following are all Perl or Python scripts and are all [ARRAY] type values
+#   such that a command with multiple arguments can be provided.
+#   You can specify these as follows.
+# 1. If perl or python is not in PATH, or you are unsure:
+#    "/path/to/perl" "/path/to/script.pl"
+#      or:
+#    "C:\Strawberry\perl\bin\perl.exe" "C:\path\to\script.pl"
+# 2. If perl/python is in PATH:
+#    "perl" "/path/to/script.pl"
+#      or:
+#    "perl" "C:\path\to\script.pl"
+# 3. If you are in a UNIX-like environment, perl/python is in PATH, and the
+#    script file has executable permissions:
+#    "/path/to/script.pl"
+
+# [ARRAY] Dualstrusion post-processing script.
+#   See https://github.com/DrLex0/DualstrusionPostproc for more information.
+
+#DUALSTRUDE_SCRIPT = "/Your/path/to/dualstrusion-postproc.pl"
+
+# [ARRAY] PWM postprocessor script, in case you would be using the
+#   MightyVariableFan system, my slightly crazy solution to obtain variable
+#   fan speed by having the FFCP communicate with a Raspberry Pi through beep
+#   sounds. You can pass extra options like "--allow_split" by adding them to
+#   the array.
+# See https://github.com/DrLex0/MightyVariableFan for more information.
+
+#PWM_SCRIPT = "/Your/path/to/pwm_postprocessor.py" "--allow_split"
+
+# [ARRAY] Path to the (experimental) retraction improver script.
+#   It also fixes the under-extrusion when starting to print the skirt.
+
+#RETRACT_SCRIPT = "/Your/path/to/retraction-improver.pl"
+
+
+### ADVANCED OPTIONS ###
+# Only change these if you know what you're doing.
+
+# [SINGLE] The absolutely highest Z value allowed by your printer.
+#   This both acts as a sanity check and will also update the final Z move in
+#   the end G-code when necessary. (If you would print something 160mm tall,
+#   the default move to 150mm must be adjusted to avoid ramming the nozzle
+#   into the print.)
+# According to official FFCP specs, Z maximum is 150mm, and this limit is
+#   hard-coded in older versions of the Sailfish firmware: it will ignore any
+#   request to go beyond 150mm. Some newer versions do allow to go beyond
+#   this, my printer can easily reach 170mm.
+# If you want to get the most out of your machine, do a test to see how deep
+#   the bed can go and adjust Z_MAX accordingly, as well as 'Max print height'
+#   in all your printer profiles.
+
+Z_MAX = 150
+
+# [SINGLE] For the above to work, this must match the comment string that
+#   marks the final Z move in the end G-code.
+
+FINAL_Z_MOVE = "; send Z axis to bottom of machine"
+
+# [SINGLE] Machine type for GPX.
+#   Run `gpx -?` and look at the 'MACHINE' section. If it lists 'fcp' as one
+#   of the allowed values, it is preferable to use that value here. Otherwise,
+#   stick to "r1d", or use something custom if you know what you're doing.
+
+MACHINE = r1d


### PR DESCRIPTION
Requiring users to edit the Perl script is a bad idea, and it made
updates annoying because the configuration had to be manually
transferred to new editions of the script.

The configuration is now in a file that by default is looked for in the
same path as the script. Other locations can be passed with `-f`.

You will have to do a one-time migration to this new config system.
Migration tips:
* Convert single to double quotes and omit commas in lists.
* Do not copy the semicolons.